### PR TITLE
Fix parsing logic for Molpro frequency data

### DIFF
--- a/get_freq_molden.py
+++ b/get_freq_molden.py
@@ -1,4 +1,13 @@
 import numpy as np
+from lib_freq_molden import (
+    read_molpro_output,
+    extract_freqcord,
+    extract_geometry,
+    extract_freqs,
+    extract_normal_modes,
+    extract_nm_lowf,
+    write_molden,
+)
 
 molpro_out="MOLPRO.out"
 molden_file="freq.molden"

--- a/lib_freq_molden.py
+++ b/lib_freq_molden.py
@@ -12,7 +12,11 @@ def extract_freqcord(data):
     blank_line_seen=False
     nat=0
     for line in data:
-        if 'Nr' and 'Atom' and 'Charge' in line:
+        # the check below was incorrectly written as
+        # `if 'Nr' and 'Atom' and 'Charge' in line:` which in Python only
+        # verifies the last condition due to short circuit evaluation.
+        # The intention is to start reading when all keywords are present.
+        if 'Nr' in line and 'Atom' in line and 'Charge' in line:
             start=True
             blank_line_seen=False
             continue
@@ -112,10 +116,8 @@ def extract_normal_modes(data,nfreq,nat):
     nm_freq=np.zeros((nat, nfreq, ncoord))
 
     nm_freq_start=False
-    if nfreq < 5:
-        nblocks=1
-    else:
-       nblocks=nfreq%5+1
+    # number of 5-mode blocks needed to store all frequencies
+    nblocks = (nfreq + 4) // 5
     print(nfreq,nblocks,nfreq%5)
 
     blank_line=[]
@@ -163,7 +165,8 @@ def extract_nm_lowf(data,nlowf,nat):
 
     nm_lowf_start=False
 
-    nblocks=nlowf%5+1
+    # each block contains up to 5 modes
+    nblocks = (nlowf + 4) // 5
     blank_nm_lowf=False
 
     blank_line=[]


### PR DESCRIPTION
## Summary
- fix conditional logic in `extract_freqcord`
- correctly determine number of blocks when parsing normal modes
- update `get_freq_molden.py` to import parser functions

## Testing
- `python -m py_compile lib_freq_molden.py get_freq_molden.py`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68404423b2908326a957d6c185423416